### PR TITLE
Start supporting Symfony 4.x, etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ git:
 
 matrix:
   include:
-    - php: 5.3
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
     - php: 7
     - php: 7.1
+    - php: 7.2
     - php: hhvm
       sudo: required
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ matrix:
     - php: 7
     - php: 7.1
     - php: 7.2
-    - php: hhvm
-      sudo: required
-      dist: trusty
-      group: edge
 
 before_script:
     - composer self-update

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ StreamedCsvResponse
 [![License](https://poser.pugx.org/issei-m/streamed-csv-response/license.svg)](https://packagist.org/packages/issei-m/streamed-csv-response)
 
 Extending the `Symfony\Component\HttpFoundation\StreamedResponse` to send a CSV file to client.
-It works with Symfony 2.3 and newer (including 3) on PHP 5.x (5.3.3 and newer) / 7.x / hhvm.
+It works with Symfony 2.7 and newer (including 3 and 4 of course) on PHP 7.x.
 
 Usage
 -----

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-foundation": "~2.3|~3.0"
+        "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^6.5"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": "^7.0",
         "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0"
     },
     "require-dev": {

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Tests;
 
 use Issei\StreamedCsvResponse;
+use PHPUnit\Framework\TestCase;
 
-class FunctionalTest extends \PHPUnit_Framework_TestCase
+class FunctionalTest extends TestCase
 {
     public function rowsProvider()
     {

--- a/tests/StreamedCsvResponse/CsvWriterTest.php
+++ b/tests/StreamedCsvResponse/CsvWriterTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Tests\StreamedCsvResponse;
 
 use Issei\StreamedCsvResponse\CsvWriter;
+use PHPUnit\Framework\TestCase;
 
-class CsvWriterTest extends \PHPUnit_Framework_TestCase
+class CsvWriterTest extends TestCase
 {
     /**
      * @test

--- a/tests/StreamedCsvResponseTest.php
+++ b/tests/StreamedCsvResponseTest.php
@@ -3,8 +3,9 @@
 namespace Issei\Tests;
 
 use Issei\StreamedCsvResponse;
+use PHPUnit\Framework\TestCase;
 
-class StreamedCsvResponseTest extends \PHPUnit_Framework_TestCase
+class StreamedCsvResponseTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
- Start supporting Symfony 4.x, meanwhile 2.3.x is dropped
- Modify minimum required PHP version to 7.x
- Drop supporting HHVM