### PR TITLE
Start supporting PHP 5.x and HHVM again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,18 @@ git:
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
     - php: 7
     - php: 7.1
     - php: 7.2
+    - php: hhvm
+      sudo: required
+      dist: trusty
+      group: edge
 
 before_script:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         }
     },
     "require": {
-        "php": "^7.0",
+        "php": ">=5.3.3",
         "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^4.8 || ^6.5"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
We think again we should support PHP 5.x until we dropped Symfony 2.x which also supports PHP 5.x.